### PR TITLE
Use Nix in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
-      - name: Build
+      - name: Build (Nix)
         run: nix build --quiet
 
       - name: Test
-        run: nix develop --quiet -c npm test
+        run: nix develop --quiet -c bash -c "npm ci && npm test"


### PR DESCRIPTION
## Summary

- Replace Node.js setup with Nix for reproducible builds
- Use paolino/dev-assets/setup-nix with Cachix

Closes #3