### PR TITLE
docs: improve Claude Code installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Requires [gh CLI](https://cli.github.com/) installed and authenticated.
 
 ### With Nix (recommended)
 
-Add to Claude Code MCP configuration:
+Add to your Claude Code settings (`~/.claude/settings.json`):
 
 ```json
 {
@@ -35,6 +35,8 @@ Add to Claude Code MCP configuration:
 }
 ```
 
+Or use `/settings` in Claude Code to add the MCP server through the UI.
+
 ### From source
 
 ```bash
@@ -43,16 +45,20 @@ cd mcp-merge-guard
 npm install && npm run build
 ```
 
+Add to `~/.claude/settings.json` (use absolute path):
+
 ```json
 {
   "mcpServers": {
     "merge-guard": {
       "command": "node",
-      "args": ["/path/to/mcp-merge-guard/dist/index.js"]
+      "args": ["/absolute/path/to/mcp-merge-guard/dist/index.js"]
     }
   }
 }
 ```
+
+Restart Claude Code after adding the configuration.
 
 ## Usage
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,11 +3,32 @@
 ## Prerequisites
 
 - [gh CLI](https://cli.github.com/) installed and authenticated
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI installed
 - Node.js 20+ (if running from source)
 
-## Using Nix (Recommended)
+## Adding to Claude Code
 
-Add to your Claude Code MCP configuration (`~/.claude.json` or project `.claude/settings.json`):
+Claude Code supports MCP servers through its settings. You can configure them at two levels:
+
+- **User-level** (`~/.claude/settings.json`) - Available in all projects
+- **Project-level** (`.claude/settings.json`) - Available only in that project
+
+### Using the CLI (Recommended)
+
+The easiest way to add the MCP server is through the Claude Code settings interface:
+
+1. Start Claude Code in any directory
+2. Type `/settings` to open the settings menu
+3. Navigate to **MCP Servers**
+4. Add a new server with the configuration below
+
+### Manual Configuration
+
+Alternatively, edit the settings file directly.
+
+#### With Nix (Recommended)
+
+Add to `~/.claude/settings.json` (create if it doesn't exist):
 
 ```json
 {
@@ -20,9 +41,9 @@ Add to your Claude Code MCP configuration (`~/.claude.json` or project `.claude/
 }
 ```
 
-## From Source
+#### From Source
 
-Clone and build:
+Clone and build first:
 
 ```bash
 git clone https://github.com/paolino/mcp-merge-guard
@@ -31,25 +52,37 @@ npm install
 npm run build
 ```
 
-Add to Claude Code configuration:
+Then add to `~/.claude/settings.json`:
 
 ```json
 {
   "mcpServers": {
     "merge-guard": {
       "command": "node",
-      "args": ["/path/to/mcp-merge-guard/dist/index.js"]
+      "args": ["/absolute/path/to/mcp-merge-guard/dist/index.js"]
     }
   }
 }
 ```
 
+!!! warning "Use absolute paths"
+    The `args` path must be absolute. Relative paths won't work since Claude Code may run from any directory.
+
 ## Verifying Installation
 
-After adding the MCP server, restart Claude Code and verify the tools are available:
+After adding the MCP server:
+
+1. **Restart Claude Code** - MCP servers are loaded at startup
+2. **Check available tools** - Ask Claude:
 
 ```
 What MCP tools are available for merging PRs?
 ```
 
 You should see `check-merge-ready` and `guard-merge` listed.
+
+3. **Test with a real PR** - Try checking a PR status:
+
+```
+Check if PR #1 in your-org/your-repo is ready to merge
+```


### PR DESCRIPTION
## Summary

- Add clearer instructions for installing the MCP server in Claude Code
- Document the `/settings` command as an alternative to manual config editing
- Explain user-level vs project-level configuration
- Add warning about using absolute paths
- Expand verification steps with practical test example

## Test plan

- [ ] Verify docs render correctly on GitHub
- [ ] Test installation following the new instructions