### PR TITLE
feat: add release pipeline with Docker image publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,146 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., 1.2.0)'
+        required: true
+        type: string
+      dry_run:
+        description: 'Dry run (skip actual release)'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate version format
+        run: |
+          VERSION="${{ inputs.version }}"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Invalid version format: $VERSION"
+            echo "Expected format: MAJOR.MINOR.PATCH (e.g., 1.2.0)"
+            exit 1
+          fi
+          echo "Version format valid: $VERSION"
+
+      - name: Check tag doesn't exist
+        run: |
+          VERSION="${{ inputs.version }}"
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "Tag v$VERSION already exists!"
+            exit 1
+          fi
+          echo "Tag v$VERSION is available"
+
+  test:
+    runs-on: ubuntu-latest
+    needs: validate
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: paolino/dev-assets/setup-nix@v0.0.1
+        with:
+          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: Build
+        run: nix build --quiet
+
+      - name: Run tests
+        run: nix develop --quiet -c npm ci && nix develop --quiet -c npm test
+
+      - name: Lint
+        run: nix develop --quiet -c npm run lint
+
+      - name: Build Docker image
+        run: nix build .#docker-image --quiet
+
+  release:
+    runs-on: ubuntu-latest
+    needs: test
+    if: ${{ !inputs.dry_run }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: paolino/dev-assets/setup-nix@v0.0.1
+        with:
+          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Update package.json version
+        run: |
+          npm version "${{ inputs.version }}" --no-git-tag-version
+          git add package.json package-lock.json
+          git commit -m "chore: bump version to ${{ inputs.version }}"
+          git push
+
+      - name: Create and push tag
+        run: |
+          git tag "v${{ inputs.version }}"
+          git push origin "v${{ inputs.version }}"
+
+      - name: Build Docker image
+        run: |
+          nix build .#docker-image
+          docker load < result
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push Docker image
+        run: |
+          VERSION="${{ inputs.version }}"
+          docker push "ghcr.io/paolino/mcp-merge-guard:$VERSION"
+          docker tag "ghcr.io/paolino/mcp-merge-guard:$VERSION" \
+            "ghcr.io/paolino/mcp-merge-guard:latest"
+          docker push "ghcr.io/paolino/mcp-merge-guard:latest"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ inputs.version }}" \
+            --title "v${{ inputs.version }}" \
+            --generate-notes
+
+  dry-run-summary:
+    runs-on: ubuntu-latest
+    needs: test
+    if: ${{ inputs.dry_run }}
+    steps:
+      - name: Dry run summary
+        run: |
+          echo "Dry run completed successfully!"
+          echo ""
+          echo "Would have:"
+          echo "  - Updated package.json version to ${{ inputs.version }}"
+          echo "  - Created tag v${{ inputs.version }}"
+          echo "  - Pushed ghcr.io/paolino/mcp-merge-guard:${{ inputs.version }}"
+          echo "  - Pushed ghcr.io/paolino/mcp-merge-guard:latest"
+          echo "  - Created GitHub Release v${{ inputs.version }}"

--- a/flake.nix
+++ b/flake.nix
@@ -44,11 +44,16 @@
             mainProgram = "mcp-merge-guard";
           };
         };
+        docker-image = import ./nix/docker-image.nix {
+          inherit pkgs mcp-merge-guard version;
+        };
       in {
         packages = {
           default = mcp-merge-guard;
-          mcp-merge-guard = mcp-merge-guard;
+          inherit mcp-merge-guard docker-image;
         };
+
+        inherit version;
 
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [

--- a/nix/docker-image.nix
+++ b/nix/docker-image.nix
@@ -1,0 +1,44 @@
+{
+  pkgs,
+  mcp-merge-guard,
+  version,
+}:
+let
+  startScript = pkgs.writeShellScript "start-mcp-merge-guard" ''
+    set -euo pipefail
+    exec ${pkgs.nodejs}/bin/node /app/dist/index.js "$@"
+  '';
+in
+pkgs.dockerTools.buildImage {
+  name = "ghcr.io/paolino/mcp-merge-guard";
+  tag = version;
+
+  copyToRoot = pkgs.buildEnv {
+    name = "mcp-merge-guard-root";
+    paths = [
+      pkgs.nodejs
+      pkgs.gh
+      pkgs.cacert
+      pkgs.bashInteractive
+      pkgs.coreutils
+    ];
+    pathsToLink = [
+      "/bin"
+      "/lib"
+    ];
+  };
+
+  extraCommands = ''
+    mkdir -p app tmp
+    cp -r ${mcp-merge-guard}/lib/* app/
+  '';
+
+  config = {
+    Cmd = [ startScript ];
+    WorkingDir = "/app";
+    Env = [
+      "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+      "HOME=/tmp"
+    ];
+  };
+}


### PR DESCRIPTION
## Summary

- Add manual release workflow with version validation and dry-run support
- Build Docker images via Nix and publish to ghcr.io
- Expose version from flake.nix for CI consumption
- Add justfile recipes for `build-docker` and `release`

## Release workflow

The release workflow (`workflow_dispatch`) includes:

1. **validate** - Check version format (semver) and tag availability
2. **test** - Full CI suite including Docker image build
3. **release** - Bump version, tag, push Docker image, create GitHub release
4. **dry-run** - Optional mode to test without releasing

## Usage

```bash
# Trigger release via justfile
just release 1.0.0

# Dry run first
just release 1.0.0 true

# Build Docker image locally
just build-docker
```

## Test plan

- [ ] Verify Docker image builds: `nix build .#docker-image`
- [ ] Test dry-run release workflow
- [ ] Test actual release