### PR TITLE
fix: run tests via nix build instead of nix develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
-      - name: Build (Nix)
+      - name: Build
         run: nix build --quiet
 
       - name: Test
-        run: nix develop --quiet -c bash -c "npm ci && npm test"
+        run: nix build .#unit-tests --quiet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,8 +60,8 @@ jobs:
       - name: Build
         run: nix build --quiet
 
-      - name: Run tests
-        run: nix develop --quiet -c bash -c "npm ci && npm test"
+      - name: Test
+        run: nix build .#unit-tests --quiet
 
   release:
     runs-on: ubuntu-latest

--- a/flake.nix
+++ b/flake.nix
@@ -44,10 +44,27 @@
             mainProgram = "mcp-merge-guard";
           };
         };
+
+        unit-tests = pkgs.buildNpmPackage {
+          pname = "mcp-merge-guard-tests";
+          inherit version;
+          src = ./.;
+          npmDepsHash = "sha256-uj3T4nBdxpau4bDm0yh44fOabc/jViz2dv7jbgETUdM=";
+
+          buildPhase = ''
+            npm run build
+            npm test
+          '';
+
+          installPhase = ''
+            mkdir -p $out
+            touch $out/tests-passed
+          '';
+        };
       in {
         packages = {
           default = mcp-merge-guard;
-          inherit mcp-merge-guard;
+          inherit mcp-merge-guard unit-tests;
         };
 
         devShells.default = pkgs.mkShell {


### PR DESCRIPTION
## Summary

Run tests via `nix build .#unit-tests` instead of `nix develop -c npm test`.

**Changes:**
- Add `unit-tests` package to flake.nix that builds and runs tests
- Update CI workflow to use `nix build .#unit-tests`
- Update release workflow to use `nix build .#unit-tests`

**Benefits:**
- Fully reproducible test runs
- No npm install needed in CI (deps come from nix)
- Cacheable via Cachix

## Test plan

- [ ] CI passes with new test approach