### PR TITLE
Fix empty reviewDecision handling

### DIFF
--- a/src/gh/types.ts
+++ b/src/gh/types.ts
@@ -15,7 +15,12 @@ export interface PrInfo {
     | "HAS_HOOKS"
     | "UNKNOWN"
     | "UNSTABLE";
-  reviewDecision: "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | null;
+  reviewDecision:
+    | "APPROVED"
+    | "CHANGES_REQUESTED"
+    | "REVIEW_REQUIRED"
+    | ""
+    | null;
   baseRefName: string;
   headRefName: string;
   headRefOid: string;

--- a/src/guards/approval.ts
+++ b/src/guards/approval.ts
@@ -16,12 +16,12 @@ export function checkApproval(prInfo: PrInfo): GuardResult {
     };
   }
 
-  if (reviewDecision === null) {
+  if (reviewDecision === null || reviewDecision === "") {
     return {
       name: "approval",
       passed: true,
       message: "No review required",
-      details: { reviewDecision: null },
+      details: { reviewDecision: reviewDecision || null },
     };
   }
 

--- a/test/guards/approval.test.ts
+++ b/test/guards/approval.test.ts
@@ -25,8 +25,20 @@ describe("checkApproval", () => {
     expect(result.message).toBe("PR is approved");
   });
 
-  it("passes when no review is required", () => {
+  it("passes when no review is required (null)", () => {
     const prInfo: PrInfo = { ...basePrInfo, reviewDecision: null };
+
+    const result = checkApproval(prInfo);
+
+    expect(result.passed).toBe(true);
+    expect(result.message).toBe("No review required");
+  });
+
+  it("passes when no review is required (empty string)", () => {
+    const prInfo: PrInfo = {
+      ...basePrInfo,
+      reviewDecision: "",
+    };
 
     const result = checkApproval(prInfo);
 


### PR DESCRIPTION
## Summary

- Handle empty string `reviewDecision` as no review required
- GitHub returns `""` when no branch protection rules require reviews

Fixes guard incorrectly failing with "Unknown review decision: "