### PR TITLE
fix: update local base branch without SSH remote dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,16 @@ MCP server that guards PR merge decisions by validating CI, approvals, conflicts
 
 - **check-merge-ready** - Query-only status check that validates all guards
 - **guard-merge** - Atomic validate-then-merge that refuses if guards fail
+  - Optional `localRepoPath` support updates the local base branch after merge
+    without relying on the clone's remote protocol
 
 ## Guards
 
-| Guard | Description |
-|-------|-------------|
-| ci-status | All CI checks passed, none pending or failed |
-| approval | PR is approved (or no review required) |
-| conflicts | No merge conflicts |
+| Guard      | Description                                            |
+| ---------- | ------------------------------------------------------ |
+| ci-status  | All CI checks passed, none pending or failed           |
+| approval   | PR is approved (or no review required)                 |
+| conflicts  | No merge conflicts                                     |
 | up-to-date | Branch is current with base (optional, off by default) |
 
 ## Installation

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -6,12 +6,12 @@ Query-only tool that checks if a PR is ready to merge by running all guards.
 
 ### Parameters
 
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `owner` | string | yes | - | Repository owner |
-| `repo` | string | yes | - | Repository name |
-| `prNumber` | number | yes | - | Pull request number |
-| `requireUpToDate` | boolean | no | false | Require branch to be up to date |
+| Parameter         | Type    | Required | Default | Description                     |
+| ----------------- | ------- | -------- | ------- | ------------------------------- |
+| `owner`           | string  | yes      | -       | Repository owner                |
+| `repo`            | string  | yes      | -       | Repository name                 |
+| `prNumber`        | number  | yes      | -       | Pull request number             |
+| `requireUpToDate` | boolean | no       | false   | Require branch to be up to date |
 
 ### Response
 
@@ -50,17 +50,18 @@ Query-only tool that checks if a PR is ready to merge by running all guards.
 Atomic tool that validates all guards and merges the PR only if all pass.
 
 !!! warning "No bypass"
-    This tool has no force flag by design. If guards fail, the merge is refused.
+This tool has no force flag by design. If guards fail, the merge is refused.
 
 ### Parameters
 
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `owner` | string | yes | - | Repository owner |
-| `repo` | string | yes | - | Repository name |
-| `prNumber` | number | yes | - | Pull request number |
-| `requireUpToDate` | boolean | no | false | Require branch to be up to date |
-| `mergeMethod` | string | no | "rebase" | Merge method: "merge", "squash", or "rebase" |
+| Parameter         | Type    | Required | Default  | Description                                                                  |
+| ----------------- | ------- | -------- | -------- | ---------------------------------------------------------------------------- |
+| `owner`           | string  | yes      | -        | Repository owner                                                             |
+| `repo`            | string  | yes      | -        | Repository name                                                              |
+| `prNumber`        | number  | yes      | -        | Pull request number                                                          |
+| `requireUpToDate` | boolean | no       | false    | Require branch to be up to date                                              |
+| `mergeMethod`     | string  | no       | "rebase" | Merge method: "merge", "squash", or "rebase"                                 |
+| `localRepoPath`   | string  | no       | -        | Local repo path whose base branch should be updated after a successful merge |
 
 ### Successful Response
 
@@ -71,6 +72,7 @@ Atomic tool that validates all guards and merges the PR only if all pass.
   "prNumber": 42,
   "merged": true,
   "sha": "abc123def456",
+  "localSync": "Local main updated at /code/my-project",
   "report": {
     "allPassed": true,
     "guards": [...],
@@ -78,6 +80,11 @@ Atomic tool that validates all guards and merges the PR only if all pass.
   }
 }
 ```
+
+When `localRepoPath` is provided, `guard-merge` fetches the merged base branch
+from GitHub over HTTPS using the authenticated `gh` session, then fast-forwards
+the local base branch itself. This avoids depending on an SSH `origin` remote
+and avoids rebasing whichever branch happened to be checked out.
 
 ### Failed Response (Guards)
 

--- a/src/tools/guard-merge.ts
+++ b/src/tools/guard-merge.ts
@@ -1,13 +1,15 @@
 import { z } from "zod";
-import { exec } from "node:child_process";
-import { promisify } from "node:util";
 import type { MergeResult, GuardOptions, MergeMethod } from "../types.js";
-import { getPrInfo, getPrChecks, getRepoMergeSettings, mergePr } from "../gh/client.js";
+import {
+  getPrInfo,
+  getPrChecks,
+  getRepoMergeSettings,
+  mergePr,
+} from "../gh/client.js";
 import { GhMergeError } from "../gh/errors.js";
 import { runGuards } from "../guards/index.js";
 import { checkMergeMethod } from "../guards/merge-method.js";
-
-const execAsync = promisify(exec);
+import { syncLocalBaseBranch } from "./local-sync.js";
 
 export const guardMergeSchema = z.object({
   owner: z.string().describe("Repository owner (user or organization)"),
@@ -27,37 +29,12 @@ export const guardMergeSchema = z.object({
     .string()
     .optional()
     .describe(
-      "Local repo path to update after merge. " +
-        "Runs git fetch + rebase on the base branch."
+      "Local repo path whose base branch should be updated after merge. " +
+        "Fetches the merged base branch over GitHub HTTPS and fast-forwards the local base branch.",
     ),
 });
 
 export type GuardMergeInput = z.infer<typeof guardMergeSchema>;
-
-/**
- * Update the local base branch after a successful remote merge.
- * Returns a status message.
- */
-async function pullBaseBranch(
-  repoPath: string,
-  baseBranch: string
-): Promise<string> {
-  try {
-    await execAsync(
-      `git -C '${repoPath}' fetch origin ${baseBranch}`,
-      { timeout: 30000 }
-    );
-    await execAsync(
-      `git -C '${repoPath}' rebase origin/${baseBranch}`,
-      { timeout: 30000 }
-    );
-    return `Local ${baseBranch} updated`;
-  } catch (error: unknown) {
-    const msg =
-      error instanceof Error ? error.message : String(error);
-    return `Local update failed: ${msg}`;
-  }
-}
 
 /**
  * Validate guards and merge PR if all pass
@@ -77,7 +54,10 @@ export async function guardMerge(input: GuardMergeInput): Promise<MergeResult> {
   const report = runGuards({ prInfo, checks, statuses, options });
 
   // Add merge-method guard result
-  const mergeMethodGuard = checkMergeMethod(mergeMethod as MergeMethod, repoSettings);
+  const mergeMethodGuard = checkMergeMethod(
+    mergeMethod as MergeMethod,
+    repoSettings,
+  );
   report.guards.push(mergeMethodGuard);
   if (!mergeMethodGuard.passed) {
     report.allPassed = false;
@@ -103,15 +83,17 @@ export async function guardMerge(input: GuardMergeInput): Promise<MergeResult> {
       owner,
       repo,
       prNumber,
-      mergeMethod as MergeMethod
+      mergeMethod as MergeMethod,
     );
 
     // Update local repo if path provided and merge succeeded
     let localSync: string | undefined;
     if (localRepoPath && mergeResponse.merged) {
-      localSync = await pullBaseBranch(
+      localSync = await syncLocalBaseBranch(
         localRepoPath,
-        prInfo.baseRefName
+        owner,
+        repo,
+        prInfo.baseRefName,
       );
     }
 

--- a/src/tools/local-sync.ts
+++ b/src/tools/local-sync.ts
@@ -1,0 +1,174 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const COMMAND_TIMEOUT_MS = 30000;
+
+interface WorktreeInfo {
+  path: string;
+  branch?: string;
+}
+
+function buildGithubRemoteUrl(owner: string, repo: string): string {
+  return `https://github.com/${owner}/${repo}.git`;
+}
+
+function buildGithubAuthHeader(token: string): string {
+  const credentials = Buffer.from(`x-access-token:${token.trim()}`).toString(
+    "base64",
+  );
+  return `AUTHORIZATION: basic ${credentials}`;
+}
+
+async function execGit(
+  repoPath: string,
+  args: string[],
+  extraArgs: string[] = [],
+): Promise<string> {
+  const { stdout } = await execFileAsync(
+    "git",
+    ["-C", repoPath, ...extraArgs, ...args],
+    {
+      timeout: COMMAND_TIMEOUT_MS,
+      encoding: "utf-8",
+    },
+  );
+
+  return stdout;
+}
+
+async function getGhToken(): Promise<string> {
+  const { stdout } = await execFileAsync("gh", ["auth", "token"], {
+    timeout: COMMAND_TIMEOUT_MS,
+    encoding: "utf-8",
+  });
+
+  return stdout.trim();
+}
+
+function parseWorktrees(output: string): WorktreeInfo[] {
+  const worktrees: WorktreeInfo[] = [];
+  let current: Partial<WorktreeInfo> = {};
+
+  for (const line of output.split("\n")) {
+    if (line.startsWith("worktree ")) {
+      if (current.path) {
+        worktrees.push(current as WorktreeInfo);
+      }
+      current = { path: line.slice("worktree ".length) };
+      continue;
+    }
+
+    if (line.startsWith("branch ")) {
+      current.branch = line.slice("branch ".length);
+      continue;
+    }
+
+    if (line === "" && current.path) {
+      worktrees.push(current as WorktreeInfo);
+      current = {};
+    }
+  }
+
+  if (current.path) {
+    worktrees.push(current as WorktreeInfo);
+  }
+
+  return worktrees;
+}
+
+async function listWorktrees(repoPath: string): Promise<WorktreeInfo[]> {
+  const output = await execGit(repoPath, ["worktree", "list", "--porcelain"]);
+  return parseWorktrees(output);
+}
+
+function findBaseBranchWorktree(
+  worktrees: WorktreeInfo[],
+  baseBranch: string,
+  preferredPath: string,
+): WorktreeInfo | undefined {
+  const branchRef = `refs/heads/${baseBranch}`;
+  return (
+    worktrees.find(
+      (worktree) =>
+        worktree.path === preferredPath && worktree.branch === branchRef,
+    ) ?? worktrees.find((worktree) => worktree.branch === branchRef)
+  );
+}
+
+async function fetchBaseBranch(
+  repoPath: string,
+  owner: string,
+  repo: string,
+  baseBranch: string,
+): Promise<void> {
+  const token = await getGhToken();
+  const remoteUrl = buildGithubRemoteUrl(owner, repo);
+  const authHeader = buildGithubAuthHeader(token);
+
+  await execGit(
+    repoPath,
+    [
+      "fetch",
+      "--prune",
+      remoteUrl,
+      `+refs/heads/${baseBranch}:refs/remotes/origin/${baseBranch}`,
+    ],
+    ["-c", `http.extraHeader=${authHeader}`],
+  );
+}
+
+async function fastForwardCheckedOutBaseBranch(
+  worktreePath: string,
+  baseBranch: string,
+): Promise<void> {
+  await execGit(worktreePath, [
+    "merge",
+    "--ff-only",
+    `refs/remotes/origin/${baseBranch}`,
+  ]);
+}
+
+async function updateLocalBaseBranchRef(
+  repoPath: string,
+  baseBranch: string,
+): Promise<void> {
+  await execGit(repoPath, [
+    "branch",
+    "--force",
+    baseBranch,
+    `refs/remotes/origin/${baseBranch}`,
+  ]);
+}
+
+export async function syncLocalBaseBranch(
+  repoPath: string,
+  owner: string,
+  repo: string,
+  baseBranch: string,
+): Promise<string> {
+  try {
+    await fetchBaseBranch(repoPath, owner, repo, baseBranch);
+
+    const worktrees = await listWorktrees(repoPath);
+    const baseBranchWorktree = findBaseBranchWorktree(
+      worktrees,
+      baseBranch,
+      repoPath,
+    );
+
+    if (baseBranchWorktree) {
+      await fastForwardCheckedOutBaseBranch(
+        baseBranchWorktree.path,
+        baseBranch,
+      );
+      return `Local ${baseBranch} updated at ${baseBranchWorktree.path}`;
+    }
+
+    await updateLocalBaseBranchRef(repoPath, baseBranch);
+    return `Local ${baseBranch} ref updated`;
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return `Local update failed: ${msg}`;
+  }
+}

--- a/test/tools/local-sync.test.ts
+++ b/test/tools/local-sync.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const execFileMock = vi.fn();
+
+vi.mock("node:child_process", () => ({
+  execFile: execFileMock,
+}));
+
+function queueExecFileResult(stdout: string, stderr = ""): void {
+  execFileMock.mockImplementationOnce(
+    (
+      _file: string,
+      _args: string[],
+      _options: Record<string, unknown>,
+      callback: (
+        error: Error | null,
+        result: { stdout: string; stderr: string },
+      ) => void,
+    ) => {
+      callback(null, { stdout, stderr });
+    },
+  );
+}
+
+describe("syncLocalBaseBranch", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  it("fast-forwards the checked out base branch worktree over HTTPS", async () => {
+    queueExecFileResult("gh-token\n");
+    queueExecFileResult("");
+    queueExecFileResult(
+      ["worktree /repo", "HEAD abcdef", "branch refs/heads/main", ""].join(
+        "\n",
+      ),
+    );
+    queueExecFileResult("");
+
+    const { syncLocalBaseBranch } =
+      await import("../../src/tools/local-sync.js");
+    const result = await syncLocalBaseBranch(
+      "/repo",
+      "paolino",
+      "demo",
+      "main",
+    );
+
+    expect(result).toBe("Local main updated at /repo");
+    expect(execFileMock).toHaveBeenCalledTimes(4);
+
+    const fetchArgs = execFileMock.mock.calls[1]?.[1] as string[];
+    expect(fetchArgs).toContain("fetch");
+    expect(fetchArgs).toContain("https://github.com/paolino/demo.git");
+    expect(fetchArgs).not.toContain("origin");
+
+    const fetchConfigArgs = fetchArgs.slice(0, 4);
+    expect(fetchConfigArgs[0]).toBe("-C");
+    expect(fetchConfigArgs[2]).toBe("-c");
+    expect(fetchConfigArgs[3]).toContain(
+      "http.extraHeader=AUTHORIZATION: basic ",
+    );
+
+    const mergeArgs = execFileMock.mock.calls[3]?.[1] as string[];
+    expect(mergeArgs).toContain("merge");
+    expect(mergeArgs).toContain("--ff-only");
+    expect(mergeArgs).not.toContain("rebase");
+  });
+
+  it("updates the local base branch ref when the branch is not checked out", async () => {
+    queueExecFileResult("gh-token\n");
+    queueExecFileResult("");
+    queueExecFileResult(
+      [
+        "worktree /repo-feature",
+        "HEAD abcdef",
+        "branch refs/heads/feature/test",
+        "",
+      ].join("\n"),
+    );
+    queueExecFileResult("");
+
+    const { syncLocalBaseBranch } =
+      await import("../../src/tools/local-sync.js");
+    const result = await syncLocalBaseBranch(
+      "/repo-feature",
+      "paolino",
+      "demo",
+      "main",
+    );
+
+    expect(result).toBe("Local main ref updated");
+
+    const branchArgs = execFileMock.mock.calls[3]?.[1] as string[];
+    expect(branchArgs).toContain("branch");
+    expect(branchArgs).toContain("--force");
+    expect(branchArgs).toContain("main");
+    expect(branchArgs).toContain("refs/remotes/origin/main");
+  });
+
+  it("reports sync failures instead of throwing", async () => {
+    execFileMock.mockImplementationOnce(
+      (
+        _file: string,
+        _args: string[],
+        _options: Record<string, unknown>,
+        callback: (
+          error: Error | null,
+          result: { stdout: string; stderr: string },
+        ) => void,
+      ) => {
+        callback(new Error("boom"), { stdout: "", stderr: "boom" });
+      },
+    );
+
+    const { syncLocalBaseBranch } =
+      await import("../../src/tools/local-sync.js");
+    const result = await syncLocalBaseBranch(
+      "/repo",
+      "paolino",
+      "demo",
+      "main",
+    );
+
+    expect(result).toContain("Local update failed:");
+    expect(result).toContain("boom");
+  });
+});


### PR DESCRIPTION
## Summary

This fixes the local post-merge sync done by `guard-merge` when `localRepoPath` is provided.

## What changed

- replace the old `git fetch origin <base>` + `git rebase origin/<base>` flow
- fetch the merged base branch directly from `https://github.com/<owner>/<repo>.git` using the authenticated `gh` session token
- update the local base branch itself instead of rebasing whichever branch happened to be checked out
- fast-forward the base branch if it is checked out in any worktree
- otherwise update the local base branch ref directly
- add tests covering the HTTPS fetch path, the checked-out base branch case, and the ref-update fallback
- document the new `localRepoPath` behavior

## Why

The previous behavior had two separate problems:

1. It rebased the current branch in `localRepoPath`, which did not guarantee that local `main` was updated. That left later work starting from stale `main`.
2. It depended on `origin` being fetchable, which failed when the clone used SSH and SSH auth was not available even though `gh` authentication was working.

This change makes the local sync use the same GitHub auth path as the merge tool and makes the sync target the base branch itself.

## Verification

- `npm test`
- `npm run build`
- `npm run lint` still fails in this repo because ESLint 9 is installed without an `eslint.config.js`; this is pre-existing and unrelated to this change

## Review notes

The most important logic is in `src/tools/local-sync.ts`. The entry point wiring is in `src/tools/guard-merge.ts`.
